### PR TITLE
Fix: Prevent negative total price from coupon over-discount

### DIFF
--- a/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.demo.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(TotalDiscountExceededException.class)
+    public ResponseEntity<Map<String, String>> handleTotalDiscountExceededException(TotalDiscountExceededException ex) {
+        log.warn("Handling TotalDiscountExceededException: {}", ex.getMessage());
+        Map<String, String> responseBody = new HashMap<>();
+        responseBody.put("message", ex.getMessage());
+        return new ResponseEntity<>(responseBody, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/example/demo/exception/TotalDiscountExceededException.java
+++ b/src/main/java/com/example/demo/exception/TotalDiscountExceededException.java
@@ -1,0 +1,8 @@
+package com.example.demo.exception;
+
+public class TotalDiscountExceededException extends RuntimeException {
+
+    public TotalDiscountExceededException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
先前，選擇的優惠券折扣總額有可能超過購物車原始金額，導致折扣後總價出現負值。

本次提交包含以下變更：

* **調整 `CartService`**：在計算過程中，檢查若套用某張優惠券（連同目前已套用的優惠券）會使總折扣超過購物車原始金額，則拒絕套用。
* **若超出上限**，拋出 `TotalDiscountExceededException`。
* **新增 `TotalDiscountExceededException.java`**。
* **實作 `GlobalExceptionHandler.java`**，並以 `@ControllerAdvice` 處理 `TotalDiscountExceededException`，回傳 HTTP 400（Bad Request），JSON 內容範例：`{"message": "所選優惠券總折價已達上限，無法套用更多優惠券"}`。
* **驗證 `checkout.mustache` 既有前端 JavaScript** 能正確處理此錯誤：

  * 顯示後端回傳的錯誤訊息。
  * 取消勾選導致錯誤的優惠券。
  * 重新計算購物車金額。

此修正確保折扣後總價不會變成負值，並依照需求提供清晰的使用者回饋。

> 注意：此修正僅透過限制已選優惠券總折扣來解決負值問題，並未改變 README 中 AD6 提到的「擇一使用」策略與多重優惠併用的底層邏輯。
